### PR TITLE
Eval.py bug fix for clipscore

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -54,9 +54,15 @@ class COCOEvalCap:
             print('computing %s score...'%(scorer.method()))
             score, scores = scorer.compute_score(gts, res)
             if type(method) == list:
-                for sc, scs, m in zip(score, scores, method):
+                for sc, m in zip(score, method):
                     self.setEval(sc, m)
-                    self.setImgToEvalImgs(scs, gts.keys(), m)
+                    if "CLIP" in m:
+                        scores = [i[m] for i in scores]
+                    elif 'Bleu' in m:
+                        scores = scores[method.index(m)]
+                    else:
+                        scores = scores
+                    self.setImgToEvalImgs(scores, gts.keys(), m)
                     print("%s: %0.3f"%(m, sc))
             else:
                 self.setEval(score, method)

--- a/eval.py
+++ b/eval.py
@@ -57,12 +57,13 @@ class COCOEvalCap:
                 for sc, m in zip(score, method):
                     self.setEval(sc, m)
                     if "CLIP" in m:
-                        scores = [i[m] for i in scores]
+                        scores_clip = [i[m] for i in scores]
+                        self.setImgToEvalImgs(scores_clip, gts.keys(), m)
                     elif 'Bleu' in m:
-                        scores = scores[method.index(m)]
+                        scores_bleu = scores[method.index(m)]
+                        self.setImgToEvalImgs(scores_bleu, gts.keys(), m)
                     else:
-                        scores = scores
-                    self.setImgToEvalImgs(scores, gts.keys(), m)
+                        self.setImgToEvalImgs(scores, gts.keys(), m)
                     print("%s: %0.3f"%(m, sc))
             else:
                 self.setEval(score, method)


### PR DESCRIPTION
The 'scores' variable contained only 2 scores for the CLIPScores, instead of all (length of imgs/sentences compared), due to the zip. This if-else, although not too elegant, makes sure all the right values are collected in scores and consequently in self.evalImgs. Thanks for sharing your clipscore repo online!